### PR TITLE
Replace .npmignore with 'files' word for whitelist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-# Ignore all file default
-*
-
-# Exceptional files
-!package.json
-!gravatar.js
-!README.md

--- a/package.json
+++ b/package.json
@@ -15,10 +15,6 @@
     "url": "https://github.com/xn-02f/gravatar/issues"
   },
   "homepage": "https://github.com/xn-02f/gravatar#readme",
-  "keywords": [
-    "gravatar",
-    "gravatar-api"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/xn-02f/gravatar.git"
@@ -29,5 +25,12 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^5.2.0"
-  }
+  },
+  "files": [
+    "gravatar.js"
+  ],
+  "keywords": [
+    "gravatar",
+    "gravatar-api"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xn-02f/gravatar",
-  "version": "1.0.2",
+  "version": "1.0.6",
   "description": "A library to generate gravatar image url.",
   "main": "gravatar.js",
   "scripts": {


### PR DESCRIPTION
- Delete .npmignore file.
- Use `files` word whitelist to optimize publication.