### PR TITLE
Optimize processing method when email parameter is invalid

### DIFF
--- a/gravatar.js
+++ b/gravatar.js
@@ -15,12 +15,12 @@ module.exports = (email, options) => {
 }
 
 const md5Hash = email => {
-    const MD5REG = /^[0-9a-f]{32}$/;
+    const MD5_REG = /^[0-9a-f]{32}$/;
 
     // http://en.gravatar.com/site/implement/hash/
     email = (typeof email === 'string') ? email.trim().toLowerCase() : 'unspecified';
 
-    return email.match(MD5REG) ? email : md5(email);
+    return email.match(MD5_REG) ? email : md5(email);
 }
 
 const handleOptions = obj => {

--- a/gravatar.js
+++ b/gravatar.js
@@ -16,9 +16,10 @@ module.exports = (email, options) => {
 
 const md5Hash = email => {
     const MD5_REG = /^[0-9a-f]{32}$/;
+    const UNSPECIFIED = '00000000000000000000000000000000'
 
     // http://en.gravatar.com/site/implement/hash/
-    email = (typeof email === 'string') ? email.trim().toLowerCase() : 'unspecified';
+    email = (typeof email === 'string') ? email.trim().toLowerCase() : UNSPECIFIED;
 
     return email.match(MD5_REG) ? email : md5(email);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -19,9 +19,10 @@ describe('Only One Email Parameter Test', () => {
     });
 
     it('Non-string email parameter test.', () => {
+        const UNSPECIFIED = '00000000000000000000000000000000'
         const result = gravatar(123);
 
-        expect(result).to.be.equal(baseURL + md5('unspecified'));
+        expect(result).to.be.equal(baseURL + UNSPECIFIED);
     });
 });
 


### PR DESCRIPTION
- Update unspecified default value, it can avoid one md5 calculation if email parameter is **non-string** invalid.
- Update test integration when input is non-string email parameter.
- Rename regexp variable: MD5REG => MD5_REG.