### PR TITLE
Move to ESM

### DIFF
--- a/gravatar.d.ts
+++ b/gravatar.d.ts
@@ -4,8 +4,8 @@
  * @param email - Email matching a Gravatar profile.
  * @example
  * ```
- * import gravatarUrl = require('@xn-02f/gravatar');
- * gravatarUrl('i@example.com', {s: 80});
+ * import gravatar from '@xn-02f/gravatar';
+ * gravatar('i@example.com', {s: 80});
  * //=> 'https://www.gravatar.com/avatar/961254e23a4de2aa887ac0f56ef5debf?s=80'
  * ```
  */
@@ -17,4 +17,4 @@ declare const gravatar: (
     options?: object
 ) => string;
 
-export = gravatar;
+export default gravatar;

--- a/gravatar.js
+++ b/gravatar.js
@@ -4,12 +4,12 @@
  * License: MIT
  */
 
-const md5 = require('@xn-02f/md5');
+import md5 from '@xn-02f/md5';
 
 const gravatarUrl = 'https://www.gravatar.com/avatar/';
 
-module.exports = (email, options) => {
-    queryString = (options) ? handleOptions(options) : '';
+export default (email, options) => {
+    let queryString = (options) ? handleOptions(options) : '';
 
     return gravatarUrl + md5Hash(email) + queryString;
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "@xn-02f/gravatar",
   "version": "1.3.3",
   "description": "A library to generate gravatar image url.",
+  "type": "module",
+  "exports": "./gravatar.js",
   "main": "gravatar.js",
   "types": "gravatar.d.ts",
   "scripts": {
@@ -26,6 +28,9 @@
   "devDependencies": {
     "ava": "^5.2.0",
     "tsd": "^0.28.1"
+  },
+  "engines": {
+    "node": ">=16"
   },
   "files": [
     "gravatar.js",

--- a/test/gravatar.test.js
+++ b/test/gravatar.test.js
@@ -1,10 +1,10 @@
 /*
  * This file is used to test.
  */
-const test = require('ava')
-const md5 = require('@xn-02f/md5')
+import test from 'ava'
+import md5 from '@xn-02f/md5'
 
-const gravatar = require('../gravatar')
+import gravatar from '../gravatar.js'
 
 const baseURL = 'https://www.gravatar.com/avatar/'
 const mailReg = /^[-!#$%&'*+\/0-9=?A-Z^_a-z{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/


### PR DESCRIPTION
Migrate [@xn-02f/gravatar](https://www.npmjs.com/package/@xn-02f/gravatar) to [ESM](https://nodejs.org/api/esm.html#modules-ecmascript-modules).

> [!WARNING]
> This means that the package is native [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) and no longer provides a CommonJS export.
> And require minimum [nodejs](https://nodejs.org/) version `>=16`.

Refer to the below links:
- https://github.com/sindresorhus/meta/discussions/15
- [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)