### PR TITLE
Upgrade dependencies and actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16.x
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "@xn-02f/md5": "*"
   },
   "devDependencies": {
-    "ava": "^5.2.0",
-    "tsd": "^0.28.1"
+    "ava": "^6.2.0",
+    "tsd": "^0.31.2"
   },
   "engines": {
     "node": ">=16"
@@ -37,6 +37,7 @@
     "gravatar.d.ts"
   ],
   "keywords": [
+    "avatar",
     "gravatar",
     "gravatar-api"
   ]


### PR DESCRIPTION
* Upgrade `actions/checkout` and `actions/setup-node` to `v4`, use node 20 as default runtime.
* Upgrade `ava` and `tsd` dependencies.