### PR TITLE
Bump version to `2.0.0` and add note about module compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@
 Via npm :
 
 ```bash
-$ npm i @xn-02f/gravatar
+npm i @xn-02f/gravatar
 ```
+
+> [!NOTE]
+> This library was moved to ESM from `v2`.
+>
+> If ESM doesn't work well with your node version, switch to the `1.x` version for CJS compatibility.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ npm i @xn-02f/gravatar
 ## Usage
 
 ```javascript
-const gravatar = require('@xn-02f/gravatar');
-// import gravatar from '@xn-02f/gravatar'
+const gravatar = require('@xn-02f/gravatar')
 
-const email = 'i@huiyifyj.cn';
-const options = {size: '80', default: '404'};
-gravatar(email, options);
+const email = 'i@xn--02f.com'
+const options = {size: '80', default: '404'}
+gravatar(email, options)
 ```
 
 | Parameter | Description |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xn-02f/gravatar",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "description": "A library to generate gravatar image url.",
   "type": "module",
   "exports": "./gravatar.js",


### PR DESCRIPTION
- Bump package version to `2.0.0`.
- Add note about `ESM` compatibility in README.md file.
- Remove `$` dollar sign used before commands without showing output, refer to [markdownlint#MD014](https://github.com/markdownlint/markdownlint/blob/v0.13.0/docs/RULES.md#md014---dollar-signs-used-before-commands-without-showing-output).

> ⚠ **BREAKING CHANGE**: The package is now ESM-only, to switch to the `1.x` version for CJS compatibility.